### PR TITLE
Add CAD Advisory Group topics

### DIFF
--- a/Agendas/agenda-2024-10-06.md
+++ b/Agendas/agenda-2024-10-06.md
@@ -5,5 +5,5 @@
 1. **Volunteer to take minutes**
 3. **1.0 release status**
 4. **CAD advisory group:**
-   * Presentation of a “top 10” for the issues labelled P1.
+   * Presentation of a [“top 10” for the issues labelled P1](https://github.com/orgs/FreeCAD/projects/28/views/6).
    * File structure: first results of the discussions

--- a/Agendas/agenda-2024-10-06.md
+++ b/Agendas/agenda-2024-10-06.md
@@ -4,3 +4,6 @@
 
 1. **Volunteer to take minutes**
 3. **1.0 release status**
+4. **CAD advisory group:**
+   * Presentation of a “top 10” for the issues labelled P1.
+   * File structure: first results of the discussions


### PR DESCRIPTION
Adding the presentation of most important and sorted issues labelled as P1 in the working group board.

Adding the presentation of preliminary results of file structure discussion.